### PR TITLE
Add CI workflow for Windows and Ubuntu

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        node-version: [18.x, 20.x]
+    
+    runs-on: ${{ matrix.os }}
+    
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'npm'
+    
+    - name: Install system dependencies (Ubuntu)
+      if: runner.os == 'Linux'
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libasound2-dev
+    
+    - name: Install dependencies
+      run: npm ci
+    
+    - name: Run linter
+      run: npm run lint
+    
+    - name: Run type check
+      run: npm run typecheck
+    
+    - name: Build
+      run: npm run build
+    
+    - name: Run tests
+      run: npm test


### PR DESCRIPTION
## Summary
- Add GitHub Actions CI workflow supporting both Windows and Ubuntu
- Configure matrix builds for Node.js 18.x and 20.x
- Include lint, typecheck, build, and test steps

## Test plan
- [ ] CI workflow runs successfully on push to main branch
- [ ] All build steps pass on Windows latest
- [ ] All build steps pass on Ubuntu latest
- [ ] Both Node.js versions (18.x and 20.x) pass

🤖 Generated with [Claude Code](https://claude.ai/code)